### PR TITLE
change .gitignore file adding /build and /node-modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+/build
+/node-modules


### PR DESCRIPTION
E aí amigo, olha, dei uma olhada básica no seu repositório e percebi que você tem algumas pastas desnecessárias nele. São elas a pasta "build" e a pasta "node-modules" essa segunda você não precisa se preocupar de subir ela no seu Github por que todos os pacotes eles são baixados quando você dá um yarn/npm init no projeto, pois ele lê o package.json e lá contém todas essas informações, diminuindo assim o tamanho do seu repositório. A pasta build eu não entendi exatamente pq você subiu, mas caso tenha sido para fazer algum deploy, eu recomendo que faça outro repositório privado se quiser e coloque só essa pasta build lá. Espero ter ajudado mesmo que tenha sido só essas duas linhas 😅